### PR TITLE
Add script for Google Sheets price alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # TLH-Notifications
+
+## Google Apps Script
+
+The repository includes a sample Apps Script (`script.gs`) that checks a Google Sheet for any tickers where the **Price Below Threshold?** column is `TRUE`. When one or more tickers match, the script emails `srburnett111@gmail.com` with the ticker symbols. If an error occurs, the script emails the same address with the error message.
+
+### Scheduling
+To run the script every weekday at 12:00 PM:
+
+1. Open [Google Apps Script](https://script.google.com/), create a new project and upload the contents of `script.gs`.
+2. Save the project.
+3. Click **Triggers** (clock icon) in the left-hand menu.
+4. Choose **Add Trigger**.
+   - Select `checkPriceThreshold` as the function to run.
+   - Set the event source to **Time-driven**.
+   - Under type of time based trigger select **Day timer**.
+   - Set the time of day to **12pm to 1pm**.
+   - Check the box to run **Weekdays (Mon-Fri)**.
+5. Save the trigger.
+
+The script will now execute each weekday around noon.

--- a/script.gs
+++ b/script.gs
@@ -1,0 +1,24 @@
+function checkPriceThreshold() {
+  var sheetId = '1YZR8iAR6R7g4Zi4OPff6Qsyzt2T9C8kU1O15inapvTs';
+  try {
+    var ss = SpreadsheetApp.openById(sheetId);
+    var sheet = ss.getSheets()[0];
+    var lastRow = sheet.getLastRow();
+    if (lastRow < 2) return; // no data
+    var data = sheet.getRange(2, 1, lastRow - 1, 4).getValues();
+    var tickers = [];
+    for (var i = 0; i < data.length; i++) {
+      var row = data[i];
+      if (row[3] === true || row[3] === 'TRUE') {
+        tickers.push(row[0]);
+      }
+    }
+    if (tickers.length > 0) {
+      MailApp.sendEmail('srburnett111@gmail.com', 'Tickers below threshold',
+        'The following tickers have fallen below their thresholds:\n' + tickers.join(', '));
+    }
+  } catch (e) {
+    MailApp.sendEmail('srburnett111@gmail.com', 'Error in Price Check Script', e.toString());
+    throw e;
+  }
+}


### PR DESCRIPTION
## Summary
- add `script.gs` to send email notifications when prices fall below threshold
- update README with instructions for scheduling the script on weekdays at noon

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6876b70508608325ade0d713b4007c1b